### PR TITLE
Merge fluxbranch back to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ To run on android:
 react-native run-android
 ```
 
-# Contributing Guidelines:
+# Current Thoughts About Our Native Project:
 
-Please read the [wiki](https://github.com/wevote/WeVoteReactNative/wiki)
+Please read and contribute to our [WeVoteReactNative Wiki!](https://github.com/wevote/WeVoteReactNative/wiki)
 
 # We Vote React Native - README Home
 

--- a/docs/installing/CLONING_CODE.md
+++ b/docs/installing/CLONING_CODE.md
@@ -39,23 +39,21 @@ https://github.com/\<YOUR GITHUB NAME\>/WeVoteReactNative
 
 8.Go paste your keys into http://github.com, under SSH Keys for your account.  
 
-# The fluxbranch
+## The fluxbranch
 We started the WeVoteReactNative repository by permanently forking the WeVote/WebApp (browser targeted) repository.
 
-Our 'fluxbranch' git branch is a long-lived branch off of the WeVoteReactNative repository that we use as a source 
-branch, where we work on code that is being ported to react-native.  
+Our 'fluxbranch' git branch was a long-lived branch off of the WeVoteReactNative repository that we used as a source 
+branch, where we worked on code that is being ported to react-native.  
 
-## How to use the fluxbranch
+On September 27, 2017 we merged the fluxbranch back into develop, making fluxbranch a stale branch.  **Don't use the
+fluxbranch anymore.**
 
-1. Fork this repository.
 
-2. Locally, clone your fork.
+##Other notes:
 
-3. Checkout `fluxbranch`.
+This project has an active Wiki page with some uptodate notes.  Take a look at [ReactNativeWiki](https://github.com/wevote/WeVoteReactNative/wiki)
 
-4. Create a new branch off `fluxbranch`
-
-5. Pick an unused library from the following: 
+This list of preferred libraries might be dated (as of September 27, 2017): 
 
     > 1) react router we can use [react-router-native](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-native)
     > 2) react bootstrap we can use [react-native-elements](https://github.com/react-native-training/react-native-elements) and [ReactNativeKatas](https://github.com/jondot/ReactNativeKatas)
@@ -66,17 +64,19 @@ branch, where we work on code that is being ported to react-native.
     > 7) react-bootstrap-toggle
     > 8) react-copy-to-clipboard
 
-6. Rewrite the code using the new libraries.
+Rewrite the code using the new libraries.
 
+After all the browser oriented libraries have been replaced with those for react-native, we will have a functional native 
+WeVote ballot App (See `scenes/Ballot/Ballot.js`)
 
-**Other notes:**
-After this fluxbranch is migrated completely (all the browser oriented libraries will have been replaced with those for react-native), we will have a functional native WeVote ballot App (See `scenes/Ballot/Ballot.js`)
-
-There are a few `.jsx` files in this repo. They cannot be used with react-native, I haven't removed them as they may have dependencies. If so, when running `react-native run-ios` missing dependencies will be flagged, to fix this we just need to rename the extension to `.js` and rewrite the unused libraries (if any).
+There are a few `.jsx` files in this repo. They cannot be used with react-native, I haven't removed them as they may 
+have dependencies. If so, when running `react-native run-ios` missing dependencies will be flagged, to fix this we just 
+need to rename the extension to `.js` and rewrite the unused libraries (if any).
 
 There are some components we can use within the react-native library, see [this link](https://facebook.github.io/react-native/docs/components-and-apis.html). (`Modal`, `Slider` we were using from `react-bootstrap` and `react-slick` respectively are in `react-native`), we may have to refactor how it's written but it should save a lot of work. Infact, a lot of the 3rd party libraries are included in the docs as well (eg. navigation).
 
-Other errors such as `Expected a component class, got [object, object]` are raised because we can't use html tags like `<div>`, we'll be using react-native components to do the same, `<View>`.
+Other errors such as `Expected a component class, got [object, object]` are raised because in react-native can't use HTML 
+tags like `<div>`.  In the case of each `<div>` from the WebApp code, we will instead we'll be using react-native's `<View>` component.
 
 I've commented out most of the libraries which cannot be used within the files.
 


### PR DESCRIPTION
I compared the head of WeVoteReactNative develop (Jun 14, 2017) with Rohan’s commit to WeVoteReactNative fluxbranch  (June 17, 2017)

https://github.com/wevote/WeVoteReactNative/compare/develop...f845d2a3627073e32d2baea9527976d1f3aa3356

This shows
Showing 78 changed files with 6,573 additions and 219 deletions.
70 of those files are jsx files from WebApp added to Fluxbranch — Nothing needs to be done with them.
Changes to Package.json and yarn.lock are irrelevant, which brings us to 72
Moving Ballot.js, BallotItem.js, BallotItemHeader.js, CandidateInfo.js,
MeasureInfo.js to new locations is irrelevant, which brings us to 77
Changes to an import in src/js/scenes/Main/App.js is irrelevant, which brings us to 78

So nothing in WeVoteReactNative develop needs to be brought over to fluxbranch

How to do this kind of merge:
https://stackoverflow.com/questions/2763006/make-the-current-git-branch-a-master-branch

git checkout fluxbranch
git merge --strategy=ours  origin/develop    # keep the content of this branch, but record a merge
git checkout develop
git merge fluxbranch                                      # fast-forward master up to the merge

Did a branch compare of my local develop in Webstorm with upstream/fluxbranch — there were no differences

Then I added some updates to our markdown pages.