### PR TITLE
Cookies are now fully working on both platforms.

### DIFF
--- a/src/js/template-config.js
+++ b/src/js/template-config.js
@@ -1,24 +1,30 @@
-// Note that we import these values into constants "web_app_config" and "webAppConfig" (so we can load and use them)
+import { Platform } from 'react-native';
+// Note that we import these values as webAppConfig so that we can access them
+const isIos = (Platform.OS === 'ios');
+
+const LIVE_SERVER = false;  // is this the live production server?  (false for developers with local api servers)
+
+const SERVER_ROOT_URL = LIVE_SERVER ? "https://api.wevoteusa.org/" :
+  isIos ? "http://127.0.0.1:8000/" : "http://10.0.3.2:8000/";
+const SERVER_ADMIN_ROOT_URL = LIVE_SERVER ? "https://api.wevoteusa.org/admin/" :
+  isIos ? "http://127.0.0.1:8000/admin/" : "http://10.0.3.2:8000/admin/";
+const SERVER_API_ROOT_URL = LIVE_SERVER ? "https://api.wevoteusa.org/apis/v1/" :
+  isIos ? "http://127.0.0.1:8000/apis/v1/" : "http://10.0.3.2:8000/apis/v1/";
+const URL_PROTOCOL = LIVE_SERVER ? "https://" : "http://";
+const HOSTNAME = LIVE_SERVER ? "WeVote.US" : "localhost:3000";
+
 module.exports = {
-  //  WE_VOTE_URL_PROTOCOL: "http://",  // "http://" for local dev or "https://" for live server
-  //  WE_VOTE_HOSTNAME: "localhost:3000",  // This should be without "http...". This is "WeVote.US" on live server.
-  WE_VOTE_URL_PROTOCOL: "https://",  // "http://" for local dev or "https://" for live server
-  WE_VOTE_HOSTNAME: "wevote.us",  // This should be without "http...". This is "WeVote.US" on live server.
+  WE_VOTE_URL_PROTOCOL: URL_PROTOCOL,
+  WE_VOTE_HOSTNAME: HOSTNAME,
 
-  // Live production server
-  WE_VOTE_SERVER_ROOT_URL: "https://api.wevoteusa.org/",
-  WE_VOTE_SERVER_ADMIN_ROOT_URL: "https://api.wevoteusa.org/admin/",
-  WE_VOTE_SERVER_API_ROOT_URL: "https://api.wevoteusa.org/apis/v1/",
+  WE_VOTE_SERVER_ROOT_URL:       SERVER_ROOT_URL,
+  WE_VOTE_SERVER_ADMIN_ROOT_URL: SERVER_ADMIN_ROOT_URL,
+  WE_VOTE_SERVER_API_ROOT_URL:   SERVER_API_ROOT_URL,
 
-  // API server (Python) on localhost, from an Android emulator in a VBox
-  // WE_VOTE_SERVER_ROOT_URL: "http://10.0.3.2:8000/",
-  // WE_VOTE_SERVER_ADMIN_ROOT_URL: "http://10.0.3.2:8000/admin/",
-  // WE_VOTE_SERVER_API_ROOT_URL: "http://10.0.3.2:8000/apis/v1/",
-
-  // API server (Python) on localhost, from an iOS emulator or the WebApp
-  // WE_VOTE_SERVER_ROOT_URL: "http://127.0.0.1:8000/",
-  // WE_VOTE_SERVER_ADMIN_ROOT_URL: "http://127.0.0.1:8000/admin/",
-  // WE_VOTE_SERVER_API_ROOT_URL: "http://127.0.0.1:8000/apis/v1/",
+  DEBUG_MODE: true,
+  LOG_NATIVE_HTTP_REQUESTS: true,
+  LOG_RNRF_ROUTING: true,
+  LOG_RENDER_EVENTS: true,
 
   DEBUG_MODE: false,
   LOG_NATIVE_HTTP_REQUESTS: false,

--- a/src/js/utils/logging.js
+++ b/src/js/utils/logging.js
@@ -14,3 +14,14 @@ export function renderLog(fileName, suffix) {
   }
 }
 
+//  Log http requests and cookie CHANGES
+export function httpLog(text, res) {
+  if (webAppConfig.LOG_NATIVE_HTTP_REQUESTS) {
+    if (res) {
+      console.log(text, res);
+    } else {
+      console.log(text);
+    }
+  }
+}
+


### PR DESCRIPTION
Changed over to full use of react-native-cookies to solve a twitter
authenticate on Android bug.  A startup bug, where the device_id
in the phone cookie cache took too long to be retrieved to use on the first 
request,  was resolved with some promises changes to CookieStore and SignIn so that
the initial read of the cookie value is
completed from the phone and cached in the app, before the first ajax request.  This
keeps the voter_device_id from the previous session intact, and reused.
New logging.js, since tracking react-native-router-flux routings is very
tough with just the debugger, so there is now an LOG_RNRF_ROUTING config
option that turns on debugging.  This logging needs to be added to each
routable class to work for us.

Numerous changes to template-config.js -- now autodetects iOS and Android
and sets the URLS appropriately for debugging, and with a change to the
LIVE_SERVER constant, sets them to the live server URLs.  These will need to be
copied to your local config.js