### PR TITLE
fixes from iosdevcamp

### DIFF
--- a/docs/working/DEBUGGING_TOOLS.md
+++ b/docs/working/DEBUGGING_TOOLS.md
@@ -1,6 +1,14 @@
 # Debugging Tools and Tips
 [Go back to Readme Home](../../README.md)
 
+## The Google Chrome DevTools is available for react-native
+
+In the iOS simulator press Command+D to get the simulator debugger window (Command+M for Android)
+
+<img src="https://github.com/wevote/WeVoteReactNative/blob/develop/docs/iOS%20Debugger%20Menu.png" alt="alt text" width="600" >
+
+
+
 ## Viewing server logs
   If you would like to see the server logs while developing, you can follow these steps.
 

--- a/docs/working/DEBUGGING_TOOLS.md
+++ b/docs/working/DEBUGGING_TOOLS.md
@@ -1,18 +1,6 @@
 # Debugging Tools and Tips
 [Go back to Readme Home](../../README.md)
 
-## The Google Chrome DevTools is available for react-native
-
-In the iOS simulator press Command+D to get the simulator debugger window (Command+M for Android)
-
-<img src="https://github.com/wevote/WeVoteReactNative/blob/develop/docs/iOS%20Debugger%20Menu.png" alt="alt text" width="600" >
-
-There is a very similar menu in Android.  When you turn on "Remote debugging" in iOS the chrome tools will launch, in 
-android you may have to launch them yourself `http://localhost:8081/debugger-ui`
-
-HTTP/Ajax/XHR requests are hard to debug in simulators, since the requests go through proxy simulators.  In config.js if
-you enable LOG_NATIVE_HTTP_REQUESTS to true, much of the request info will end up in the console log in the debugger.
-
 ## Viewing server logs
   If you would like to see the server logs while developing, you can follow these steps.
 

--- a/docs/working/DEBUGGING_TOOLS.md
+++ b/docs/working/DEBUGGING_TOOLS.md
@@ -7,7 +7,11 @@ In the iOS simulator press Command+D to get the simulator debugger window (Comma
 
 <img src="https://github.com/wevote/WeVoteReactNative/blob/develop/docs/iOS%20Debugger%20Menu.png" alt="alt text" width="600" >
 
+There is a very similar menu in Android.  When you turn on "Remote debugging" in iOS the chrome tools will launch, in 
+android you may have to launch them yourself `http://localhost:8081/debugger-ui`
 
+HTTP/Ajax/XHR requests are hard to debug in simulators, since the requests go through proxy simulators.  In config.js if
+you enable LOG_NATIVE_HTTP_REQUESTS to true, much of the request info will end up in the console log in the debugger.
 
 ## Viewing server logs
   If you would like to see the server logs while developing, you can follow these steps.

--- a/ios/WeVoteReactNative.xcodeproj/xcuserdata/stevepodell.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ios/WeVoteReactNative.xcodeproj/xcuserdata/stevepodell.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>WeVoteReactNative-tvOS.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 		<key>WeVoteReactNative.xcscheme_^#shared#^_</key>
 		<dict>

--- a/src/js/components/Widgets/ItemSupportOpposeCounts.js
+++ b/src/js/components/Widgets/ItemSupportOpposeCounts.js
@@ -86,8 +86,7 @@ export default class ItemSupportOpposeCounts extends Component {
 
       <View className="network-positions__oppose">
         <View className="network-positions__count u-push--xs">
-          {!isEmpty ? oppose_count : null}
-          <Text className="sr-only"> Oppose</Text>
+          <Text className="sr-only"> {!isEmpty ? oppose_count : 0} Oppose</Text>
         </View>
         {/* 9/27/16 hack
 

--- a/src/js/scenes/Ballot/Ballot.js
+++ b/src/js/scenes/Ballot/Ballot.js
@@ -342,12 +342,6 @@ export default class Ballot extends Component {
     }
   }
 
-  // Test code, feel free to delete if you are working on adding features to this class
-  static steveCount = 0;
-  doSomething () {
-    console.log("pressed: " + ++Ballot.steveCount);
-  }
-
   // ------------------------------------------------------------------------------------------------------------------
   render () {
     logging.renderLog("Ballot.js", "scene = " + Actions.currentScene);
@@ -375,12 +369,6 @@ export default class Ballot extends Component {
           {(Actions.currentScene === 'ballot') ?
             <SelectAddressModal show={this.state.showSelectAddressModal}
                                 toggleFunction={this._toggleSelectAddressModal} /> : null }
-
-          {/* This is a test button, October 2017, anyone working on getting this page going should feel free to delete it */}
-          <TouchableOpacity style = {styles.button} onPress={this.doSomething.bind(this)}>
-            <Text style = {styles.buttonText}>Test Button</Text>
-          </TouchableOpacity>
-          {/* End of test button, October 2017 */}
 
         </View>
       </View>;
@@ -465,10 +453,10 @@ export default class Ballot extends Component {
       {emptyBallot}
       <View className="BallotList">
         { in_ready_to_vote_mode ?
-          ballot.map( (item) => <View>
+          ballot.map( (item) => <View key={item.we_vote_id}>
             <BallotItemReadyToVote key={item.we_vote_id} {...item} />
           </View>) :
-          ballot.map( (item) => <View>
+          ballot.map( (item) => <View key={item.we_vote_id}>
             <BallotItemCompressed _toggleCandidateModal={this._toggleCandidateModal}
                                                       _toggleMeasureModal={this._toggleMeasureModal}
                                                       key={item.we_vote_id}

--- a/src/js/stores/CookieStore.js
+++ b/src/js/stores/CookieStore.js
@@ -66,7 +66,8 @@ class CookieStore {
 
     if (key === 'voter_device_id') {
       if( value === this.state.current_voter_device_id ) {
-        logging.httpLog(">>>>Set cookie iOS, value for voter_device_id already cached, no need to set cookie = ", value);
+        // Please don't delete this logger
+        // logging.httpLog(">>>>Set cookie iOS, value for voter_device_id already cached, no need to set cookie = ", value);
         return;
       }
       this.state.current_voter_device_id = value;
@@ -112,17 +113,20 @@ class CookieStore {
       if (Platform.OS === 'ios') {
         CookieManager.getAll()
           .then((res) => {
-            logging.httpLog('>>>>All iOS cookies before $ajax call to (' + endpoint + ') =>', res);
+            // Please don't delete this logger
+            // logging.httpLog('>>>>All iOS cookies before $ajax call to (' + endpoint + ') =>', res);
         });
 
       } else {
         CookieManager.get('https://www.facebook.com')
           .then((res) => {
-            logging.httpLog('>>>>FACEBOOK Android cookies before $ajax call to (' + endpoint + ') =>', res);
+            // Please don't delete this logger
+            // logging.httpLog('>>>>FACEBOOK Android cookies before $ajax call to (' + endpoint + ') =>', res);
           });
         CookieManager.get(this.state.urlString)
           .then((res) => {
-            logging.httpLog('>>>>WeVoteAPI Android cookies before $ajax call to (' + endpoint + ') =>', res);
+            // Please don't delete this logger
+            // logging.httpLog('>>>>WeVoteAPI Android cookies before $ajax call to (' + endpoint + ') =>', res);
           });
       }
     }

--- a/src/js/template-config.js
+++ b/src/js/template-config.js
@@ -4,12 +4,17 @@ const isIos = (Platform.OS === 'ios');
 
 const LIVE_SERVER = false;  // is this the live production server?  (false for developers with local api servers)
 
+const USING_AVD_ANDROID = true;   // Only set to false if you are using Genymotion on Android
+
 const SERVER_ROOT_URL = LIVE_SERVER ? "https://api.wevoteusa.org/" :
-  isIos ? "http://127.0.0.1:8000/" : "http://10.0.3.2:8000/";
+  isIos ? "http://127.0.0.1:8000/" :
+    USING_AVD_ANDROID ? "http://10.0.2.2:8000/" : "http://10.0.3.2:8000/";
 const SERVER_ADMIN_ROOT_URL = LIVE_SERVER ? "https://api.wevoteusa.org/admin/" :
-  isIos ? "http://127.0.0.1:8000/admin/" : "http://10.0.3.2:8000/admin/";
+  isIos ? "http://127.0.0.1:8000/admin/" :
+    USING_AVD_ANDROID ? "http://10.0.2.2:8000/admin/" : "http://10.0.3.2:8000/admin/";
 const SERVER_API_ROOT_URL = LIVE_SERVER ? "https://api.wevoteusa.org/apis/v1/" :
-  isIos ? "http://127.0.0.1:8000/apis/v1/" : "http://10.0.3.2:8000/apis/v1/";
+  isIos ? "http://127.0.0.1:8000/apis/v1/" :
+    USING_AVD_ANDROID ? "http://10.0.2.2:8000/apis/v1/" : "http://10.0.3.2:8000/apis/v1/";
 const URL_PROTOCOL = LIVE_SERVER ? "https://" : "http://";
 const HOSTNAME = LIVE_SERVER ? "WeVote.US" : "localhost:3000";
 
@@ -20,11 +25,6 @@ module.exports = {
   WE_VOTE_SERVER_ROOT_URL:       SERVER_ROOT_URL,
   WE_VOTE_SERVER_ADMIN_ROOT_URL: SERVER_ADMIN_ROOT_URL,
   WE_VOTE_SERVER_API_ROOT_URL:   SERVER_API_ROOT_URL,
-
-  DEBUG_MODE: true,
-  LOG_NATIVE_HTTP_REQUESTS: true,
-  LOG_RNRF_ROUTING: true,
-  LOG_RENDER_EVENTS: true,
 
   DEBUG_MODE: false,
   LOG_NATIVE_HTTP_REQUESTS: false,

--- a/src/js/utils/service.js
+++ b/src/js/utils/service.js
@@ -81,6 +81,7 @@ export function $ajax (options) {
       } else {
         logging.httpLog(">>HTTP responseJson:" + options.endpoint + ' : ' + responseJson.status);
       }
+      logging.httpLog(">>HTTP response:", responseJson);
 
       const res = responseJson;
       this.dispatch({ type: options.endpoint, res });


### PR DESCRIPTION
Dale's find on the oppose_count not wrapped with <Text> 
Anisha's find in ballot where the map key has to also be in the top level component, a View in this case. 
Removed some debugging code from ballot Commented out some CookieStore logging that will be rarely needed.
In service.js, now log the full response object In template-config.js, now support the two urls for Genymotion and AVD