### PR TITLE
AccountMenu sign out is working

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ These are some videos which'll give you a brief overview of React Native.
 ## Working with WeVoteReactNative
 1. [Working with WeVoteReactNative Day-to-Day](docs/working/README_WORKING_WITH_REACT_NATIVE.md)
 
-2a. [Debugging Tools and Tips iOS](docs/working/DEBUGGING_TOOLS_IOS.md)
+2. [Working with react-native-router-flux](docs/working/WORKING_WITH_REACT_NATIVE_ROUTER_FLUX.md)
 
-2b. [Debugging Tools and Tips Android](docs/working/DEBUGGING_TOOLS_ANDROID.md)
+3a. [Debugging Tools and Tips iOS](docs/working/DEBUGGING_TOOLS_IOS.md)
 
-3. [Issues and Reporting Bugs](docs/working/ISSUES.md)
+3b. [Debugging Tools and Tips Android](docs/working/DEBUGGING_TOOLS_ANDROID.md)
+
+4. [Issues and Reporting Bugs](docs/working/ISSUES.md)
 
 ## Contributing to the Project
 Please read the following before you start contributing to the project. Thank you!

--- a/docs/working/DEBUGGING_TOOLS_IOS.md
+++ b/docs/working/DEBUGGING_TOOLS_IOS.md
@@ -1,5 +1,5 @@
 # Debugging Tools and Tips
-[Go back to Debugging Tools and Tips iOS](DEBUGGING_TOOLS_IOS.md)
+[Go back to Readme Home](../../README.md)
 
 In the iOS simulator press Command+D to get the simulator debugger window (Command+M for Android)
 

--- a/docs/working/DEBUGGING_TOOLS_IOS.md
+++ b/docs/working/DEBUGGING_TOOLS_IOS.md
@@ -1,5 +1,5 @@
 # Debugging Tools and Tips
-[Go back to Readme Home](../../README.md)
+[Go back to Debugging Tools and Tips iOS](DEBUGGING_TOOLS_IOS.md)
 
 In the iOS simulator press Command+D to get the simulator debugger window (Command+M for Android)
 

--- a/docs/working/README_WORKING_WITH_REACT_NATIVE.md
+++ b/docs/working/README_WORKING_WITH_REACT_NATIVE.md
@@ -60,6 +60,8 @@ the PyCharm IDE. How you do this depends on the development environment you use.
 
 ---
 
-Next: [Debugging Tools and Tips iOS](DEBUGGING_TOOLS_IOS.md)
+Next: [Working with react-native-router-flux](docs/working/WORKING_WITH_REACT_NATIVE_ROUTER_FLUX.md)
+
+
 
 [Go back to Readme Home](../../README.md)

--- a/docs/working/WORKING_WITH_REACT_NATIVE_ROUTER_FLUX.md
+++ b/docs/working/WORKING_WITH_REACT_NATIVE_ROUTER_FLUX.md
@@ -1,0 +1,131 @@
+# Working with react-native-router-flux (RNRF)
+
+[React-native-router-flux](https://github.com/aksonov/react-native-router-flux) (RNRF) is what we use for native routing,
+the ability to change the "scene" (the outermost component on the screen).
+
+RNRF is a wrapper that extends [react-navigation](https://github.com/react-community/react-navigation) which will become
+the core router package for react-native in the near future.
+
+RNRF allows you to create React objects that do not get unloaded from memory, the key example are the objects that you tab
+to within a menu.  There are some advantages and disadvantages of objects that don't unmount, the big disadvantage is that
+that for these objects that don't dismount, the normal [React Component Lifcycle](https://reactjs.org/docs/react-component.html)
+does not occur, for example an object that doesn't dismount, the `componentWillMount()` is only called once per application
+life.  `componentWillUnmount()` might not ever be called.  
+
+It appears that `componentDidMount()` doesn't work in react-native, but this may be a short lived bug, but in any case 
+`componentWillMount()` is a good substitute that does work.
+
+So to make up for the loss of some of the lifecycle methods, RNRF adds two new static component visibility lifecycle 
+methods `onEnter` and `onExit`.  These are a bit strange, in that they are static methods -- the value of `onEnter` is
+that it is guaranteed to be called when the component becomes visible, and it is possible to set props, or to call the
+RNRF `Actions.refresh()` which mutates state, and will force the (non-static) `componentWillReceiveProps()` to be executed
+from which any condional logic can be executed.  In the following example, the entryTime is stored in the object state, and
+it is kind of irrelvant if that variable is ever used, since its only purpsose may be to trigger a `componentWillReceiveProps()`.
+
+```
+         Actions.refresh({
+           entryTime: new Date()
+         });
+       };
+```
+If you don't mutate state in `onEnter()` the object goes directly to the `render()`
+
+## Example code
+
+```
+import React, { Component } from "react";
+import { Text, View } from 'react-native';
+import PropTypes from 'prop-types';                                             // Note 1
+import { Actions } from 'react-native-router-flux';
+
+import AddressBox from "../../components/AddressBox";                           // Note 2
+import RouteConst from "../routeConst"
+const logging = require("../../utils/logging");
+
+export default class Location extends Component {
+  static propTypes = {
+      location: PropTypes.object
+  };
+
+  constructor (props){
+    super(props);
+    this.state = {};
+  }
+
+  static onEnter = () => {                                                            // Note 3
+    logging.rnrfLog("onEnter to location: currentScene = " + Actions.currentScene);   // Note 4
+  };
+
+  static onExit = () => {
+    logging.rnrfLog("onExit from location: currentScene = " + Actions.currentScene);  // Note 5
+    Actions.refresh({came_from: RouteConst.KEY_LOCATION, forward_to_ballot: false})   // Note 6
+  };
+
+
+  render () {
+    logging.renderLog("Location", "scene = " + Actions.currentScene);                 // Note 7
+
+    return <View>
+        <AddressBox {...this.props} saveUrl="/ballot" />
+    </View>;
+  }
+}
+```
+
+**Note 1:**
+
+In the latest versions of React,  PropTypes should be imported from "prop-types", NOT from "react"
+
+
+**Note 2:**
+
+There is a convention in react-native code where library imports like "import { Actions } from `react-native-router-flux'`
+come before app code imports like `import AddressBox from "../../components/AddressBox"` with a separating line inbetween,
+and there is a WeVote convention where app code imports are alphabetized.  Please follow these conventions as a courtesy
+for other developers.
+
+**Note 3:**
+
+Every react class that is the destination of a RNRF routing, should have a `onEnter()` and an `onExit()` function at the 
+top of the file after the `propTypes()` and `constructor()`
+
+**Note 4:**
+
+Every onEnter should contain a line almost exactly like the following:
+
+`logging.rnrfLog("onEnter to location: currentScene = " + Actions.currentScene);`
+
+This logging is controlled by the `LOG_RNRF_ROUTING: true,` constant in config.js, so the logging
+can be turned off in production, and on your local if you prefer.  This logging is necessary at this
+point in react-native, since the debugger stack trace often does not tell how you got to the component.  
+
+**Note 5:**
+
+Every onExit should contain a line almost exactly like the following:
+
+logging.rnrfLog("onExit from location: currentScene = " + Actions.currentScene);
+ 
+**Note 6:**
+
+Every RNRF scene has a key like `'ballot'` for routing to `src/js/scenes/Ballot/Ballot.js`,
+but don't use that string in the code, setup a constant in `src/js/scenes/routeConst.js`
+and use it in `src/js/scenes/App.js` and everywhere else in the app where you navigate to 
+the scene defined by that key.
+
+**Note 7:**
+
+Every `render()` should have a line at the top almost exactly like the following"
+
+`logging.renderLog("Location", "scene = " + Actions.currentScene);`
+
+This logging is controlled by `LOG_RENDER_EVENTS: true,` in config.js.  It is astounding how many renders occur for some 
+objects, and this allows us to see this behaviour without using breakpoints.  (Breakpoints can be problematic in
+react-native, because unline react for webapps that is single threaded, react-native is multithreaded so sometimes
+breakpoints don't work.)
+ 
+
+---
+
+Next: [Debugging Tools and Tips iOS](DEBUGGING_TOOLS_IOS.md)
+
+[Go back to Readme Home](../../README.md)

--- a/src/js/actions/FacebookActions.js
+++ b/src/js/actions/FacebookActions.js
@@ -13,32 +13,39 @@ const web_app_config = require("../config");
 // Including FacebookStore causes problems in the WebApp, and again in the Native App
 
 
-module.exports = {
+export default class FacebookActions {
   // TODO Convert this to sign out of just Facebook
-  appLogout: function (){
+  static appLogout (){
     VoterSessionActions.voterSignOut();  // This deletes the device_id cookie
     VoterActions.voterRetrieve();
     VoterActions.voterEmailAddressRetrieve();
-  },
+  }
 
-  disconnectFromFacebook: function () {
-      // Removing connection between We Vote and Facebook
-      Dispatcher.dispatch({
-          type: FacebookConstants.FACEBOOK_SIGN_IN_DISCONNECT,
-          data: true
-      });
-  },
+  static disconnectFromFacebook () {
+    // Removing connection between We Vote and Facebook
+    Dispatcher.dispatch({
+      type: FacebookConstants.FACEBOOK_SIGN_IN_DISCONNECT,
+      data: true
+    });
+  }
 
-  facebookDisconnect: function (){
+  static facebookSignInForget () {
+    Dispatcher.dispatch({
+      type: "facebookSignInForget",
+      data: true
+    });
+  }
+
+  static facebookDisconnect (){
     Dispatcher.loadEndpoint("facebookDisconnect");
-  },
+  }
 
-  facebookFriendsAction: function () {
+  static facebookFriendsAction () {
     Dispatcher.loadEndpoint("facebookFriendsAction", {});
     FriendActions.suggestedFriendList();
-  },
+  }
 
-  getFacebookData: function (accessToken) {
+  static getFacebookData (accessToken) {
     Dispatcher.dispatch({
       type: FacebookConstants.FACEBOOK_ACCESS_TOKEN,
       data: accessToken
@@ -57,9 +64,9 @@ module.exports = {
       this.facebookApiCallbackData
     );
     new GraphRequestManager().addRequest(infoRequest).start();
-  },
+  }
 
-  facebookApiCallbackData (error: ?Object, response: ?Object) {
+  static facebookApiCallbackData (error: ?Object, response: ?Object) {
     if (error) {
       console.log('facebookApiCallbackData returned an error: ' + error.message);
     } else {
@@ -68,11 +75,11 @@ module.exports = {
         data: response
       });
     }
-  },
+  }
 
   // Save incoming data from Facebook
   // For offsets, see https://developers.facebook.com/docs/graph-api/reference/cover-photo/
-  voterFacebookSignInData: function (data) {
+  static voterFacebookSignInData (data) {
     console.log("FacebookActions voterFacebookSignInData, data:", data);
     let background = false;
     let offset_x = false;
@@ -100,10 +107,10 @@ module.exports = {
       save_auth_data: false,
       save_profile_data: true,
     });
-  },
+  }
 
   // October 2017, not yet ported to native way of doing it.  See getFacebookData
-  getFacebookInvitableFriendsList: function (picture_width, picture_height) {
+  static getFacebookInvitableFriendsList (picture_width, picture_height) {
     let fb_api_for_invitable_friends = `/me?fields=invitable_friends.limit(1000){name,id,picture.width(${picture_width}).height(${picture_height})}`;
     window.FB.api(fb_api_for_invitable_friends, (response) => {
       console.log("getFacebookInvitableFriendsList", response);
@@ -112,10 +119,10 @@ module.exports = {
           data: response
       });
     });
-  },
+  }
 
   // October 2017, not yet ported to native way of doing it.  See getFacebookData
-  readFacebookAppRequests: function () {
+  static readFacebookAppRequests () {
     let fb_api_for_reading_app_requests = "me?fields=apprequests.limit(10){from,to,created_time,id}";
     window.FB.api(fb_api_for_reading_app_requests, (response) => {
       console.log("readFacebookAppRequests", response);
@@ -124,10 +131,10 @@ module.exports = {
           data: response
       });
     });
-  },
+  }
 
   // October 2017, not yet ported to native way of doing it.  See getFacebookData
-  deleteFacebookAppRequest: function (requestId) {
+  static deleteFacebookAppRequest (requestId) {
     console.log("deleteFacebookAppRequest requestId: ", requestId);
     window.FB.api(requestId, "delete", (response) => {
       console.log("deleteFacebookAppRequest response", response);
@@ -136,10 +143,10 @@ module.exports = {
           data: response
        });
     });
-  },
+  }
 
   // Save incoming auth data from Facebook
-  voterFacebookSignInAuth: function (data) {
+  static voterFacebookSignInAuth (data) {
     console.log("FacebookActions voterFacebookSignInAuth");
     Dispatcher.loadEndpoint("voterFacebookSignInSave", {
       facebook_access_token: data.facebook_access_token || false,
@@ -149,17 +156,15 @@ module.exports = {
       save_auth_data: true,
       save_profile_data: false
     });
-  },
+  }
 
-  voterFacebookSignInRetrieve: function (){
+  static voterFacebookSignInRetrieve (){
     Dispatcher.loadEndpoint("voterFacebookSignInRetrieve", {
     });
-  },
+  }
 
-  voterFacebookSignInConfirm: function (){
+  static voterFacebookSignInConfirm (){
     Dispatcher.loadEndpoint("voterFacebookSignInRetrieve", {
     });
-  },
-};
-
-export default [];
+  }
+}

--- a/src/js/actions/TwitterActions.js
+++ b/src/js/actions/TwitterActions.js
@@ -2,41 +2,37 @@ import Dispatcher from "../dispatcher/Dispatcher";
 import VoterActions from "../actions/VoterActions";
 import VoterSessionActions from "../actions/VoterSessionActions";
 
-module.exports = {
-  // TODO Convert this to sign out of just Twitter
-  appLogout: function (){
+export default class TwitterActions {
+
+  static twitterSignInForget () {
+    Dispatcher.dispatch({
+      type: "twitterSignInForget",
+      data: true
+    });
+  }
+
+  static appLogout (){
     VoterSessionActions.voterSignOut();
     VoterActions.voterRetrieve();
-  },
+  }
 
-  twitterIdentityRetrieve: function (new_twitter_handle) {
+  static twitterIdentityRetrieve (new_twitter_handle) {
     Dispatcher.loadEndpoint("twitterIdentityRetrieve",
       {
         twitter_handle: new_twitter_handle
       });
-  },
+  }
 
-  twitterNativeSignInSave: function (twitter_access_token, twitter_access_token_secret) {
+  static twitterNativeSignInSave (twitter_access_token, twitter_access_token_secret) {
     Dispatcher.loadEndpoint("twitterNativeSignInSave",
       {
         twitter_access_token: twitter_access_token,
         twitter_access_token_secret: twitter_access_token_secret
       });
-  },
+  }
 
-  twitterSignInRetrieve: function () {
+  static twitterSignInRetrieve () {
     Dispatcher.loadEndpoint("twitterSignInRetrieve", {
     });
-  },
-
-  //
-  // twitterSignInStart: function (return_url) {
-  //   Dispatcher.loadEndpoint("twitterSignInStart",
-  //     {
-  //       return_url: return_url
-  //     });
-  // },
-
-};
-
-export default [];
+  }
+}

--- a/src/js/actions/VoterSessionActions.js
+++ b/src/js/actions/VoterSessionActions.js
@@ -1,15 +1,23 @@
 import Dispatcher from "../dispatcher/Dispatcher";
 import CookieStore from "../stores/CookieStore";
+import TwitterActions from "../actions/TwitterActions"
+import FacebookActions from "../actions/FacebookActions"
 
-module.exports = {
-  voterSignOut: function (){
-    Dispatcher.loadEndpoint("voterSignOut", {sign_out_all_devices: false});
-    CookieStore.removeItem("voter_device_id");
-    CookieStore.removeItem("voter_orientation_complete");
-  },
+export default class VoterSessionActions {
 
-  setVoterDeviceIdCookie (id) {
+  static voterSignOut (){
+    // Deleting cookies in native takes a long time, too long to delete and assume it is gone, so we just remove the
+    // authentication data from the twitter and facebook stores.
+    // CookieStore.removeItem("voter_device_id");
+    // Dispatcher.loadEndpoint("voterSignOut", {sign_out_all_devices: false});
+    console.log("Signing out of Twitter and Facebook from VoterSessionActions.voterSignOut()");
+    FacebookActions.facebookSignInForget();
+    TwitterActions.twitterSignInForget();
+    CookieStore.removeItem("voter_orientation_complete");  // Not time sensitive, so ok to remove the cookie
+  }
+
+  static setVoterDeviceIdCookie (id) {
     console.log("VoterSessionActions Setting new voter_device_id to ", id );
     CookieStore.setItem("voter_device_id", id);
   }
-};
+}

--- a/src/js/scenes/Ballot/Ballot.js
+++ b/src/js/scenes/Ballot/Ballot.js
@@ -19,6 +19,8 @@ import EditAddress from "../../components/Widgets/EditAddress";
 import VoterGuideActions from "../../actions/VoterGuideActions";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import LoadingWheel from "../../components/LoadingWheel";
+import RouteConst from "../routeConst";
+
 import SupportActions from "../../actions/SupportActions";
 import SupportStore from "../../stores/SupportStore";
 import VoterStore from "../../stores/VoterStore";
@@ -91,18 +93,18 @@ export default class Ballot extends Component {
 
   static onExit = () => {
     logging.rnrfLog("onExit from Ballot: currentScene = " + Actions.currentScene);
-    Actions.refresh({came_from: 'ballot', forward_to_ballot: false})
+    Actions.refresh({came_from: RouteConst.KEY_BALLOT, forward_to_ballot: false})
   };
 
   // componentDidMount ()  Doesn't work in react-native?
   componentWillMount () {
     console.log("Ballot ++++ MOUNT, currentScene = " + Actions.currentScene);
     this.setState({mounted: true});
-    if (Actions.currentScene === 'ballot') {
+    if (Actions.currentScene === RouteConst.KEY_BALLOT) {
       if (typeof BallotStore.ballot_properties === "undefined" || BallotStore.ballot_properties.ballot_found === false) { // No ballot found
         logging.rnrfLog("Ballot had no voter so called  AddressSelectModal");
         this.setState({showBallotSummaryModal: true});
-        //Actions.location({came_from: 'ballot'});
+        //Actions.location({came_from: RouteConst.KEY_BALLOT});
         //browserHistory.push("settings/location");
       } else {
         let ballot_type = this.props.type ? this.props.type : "all";
@@ -355,7 +357,7 @@ export default class Ballot extends Component {
   render () {
     logging.renderLog("Ballot.js", "scene = " + Actions.currentScene);
 
-    if (this.state.waitingForBallot && Actions.currentScene != 'ballot') {
+    if (this.state.waitingForBallot && Actions.currentScene != RouteConst.KEY_BALLOT) {
       console.log("Ballot waitingForBallot is true with the scene not being current, so returning null");
       return LoadingWheel;
     }
@@ -375,7 +377,7 @@ export default class Ballot extends Component {
             {sign_in_message}
           </Text>
 
-          {(Actions.currentScene === 'ballot') ?
+          {(Actions.currentScene === RouteConst.KEY_BALLOT) ?
             <SelectAddressModal show={this.state.showSelectAddressModal}
                                 toggleFunction={this._toggleSelectAddressModal} /> : null }
 

--- a/src/js/scenes/Settings/Location.js
+++ b/src/js/scenes/Settings/Location.js
@@ -6,9 +6,6 @@ import { Actions } from 'react-native-router-flux';
 import AddressBox from "../../components/AddressBox";
 import RouteConst from "../routeConst"
 const logging = require("../../utils/logging");
-//import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";
-//import Helmet from "react-helmet";
-
 
 export default class Location extends Component {
   static propTypes = {
@@ -31,8 +28,7 @@ export default class Location extends Component {
 
 
   render () {
-    // console.log("Settings/Location");
-    logging.renderLog("Location.js", "scene = " + Actions.currentScene);
+    logging.renderLog("Location", "scene = " + Actions.currentScene);
 
     return <View>
         <AddressBox {...this.props} saveUrl="/ballot" />

--- a/src/js/scenes/SignIn/AccountMenu.js
+++ b/src/js/scenes/SignIn/AccountMenu.js
@@ -9,16 +9,12 @@ import PropTypes from 'prop-types';
 import Modal from 'react-native-modal'
 import { Actions } from 'react-native-router-flux';
 
-
-import RouteConst from "../routeConst";
-import styles from "../../stylesheets/components/baseStyles";
-
-import TwitterStore from "../../stores/TwitterStore";
-import FacebookStore from "../../stores/FacebookStore";
 import BallotStore from "../../stores/BallotStore";
 import BookmarkStore from "../../stores/BookmarkStore";
 import FriendStore from "../../stores/FriendStore";
 import OrganizationActions from "../../actions/OrganizationActions";
+import RouteConst from "../routeConst";
+import styles from "../../stylesheets/components/baseStyles";
 import VoterGuideActions from "../../actions/VoterGuideActions";
 import VoterSessionActions from "../../actions/VoterSessionActions";
 const logging = require("../../utils/logging");
@@ -103,8 +99,9 @@ export default class AccountMenu extends Component {
   }
 
   signOutAndHideAccountMenu () {
+    console.log("AccountMenu signOutAndHideAccountMenu() removing twitter and facebook authentication data");
     VoterSessionActions.voterSignOut();
-    this.setState({accountMenuOpen: false});
+    this._showModal();
   }
 
   transitionToYourVoterGuide () {
@@ -179,7 +176,7 @@ let accountMenuOpen = true;
         backdropOpacity={1}
         style={{
           left: 20,
-          top: 20,
+          top: 35,
           backgroundColor: 'white',
          }}
       >
@@ -194,7 +191,7 @@ let accountMenuOpen = true;
             <TouchableOpacity onPress={this._showModal}>
               <Text style={styles.modalChoices}>Sign In</Text>
             </TouchableOpacity>
-            <TouchableOpacity onPress={this._showModal}>
+            <TouchableOpacity onPress={this.signOutAndHideAccountMenu.bind(this)}>
               <Text style={styles.modalChoices}>Sign Out</Text>
             </TouchableOpacity>
             <Text style={styles.modalChoiceDummy}>Your Bookmarked Items</Text>

--- a/src/js/scenes/SignIn/SignIn.js
+++ b/src/js/scenes/SignIn/SignIn.js
@@ -215,11 +215,11 @@ export default class SignIn extends Component {
 
   render () {
     if (Actions.currentScene !== "signIn") {
-      logging.renderLog("SignIn", "when NOT CURRENT, scene  = " + Actions.currentScene);
+      logging.renderLog("SignIn when NOT CURRENT, scene  = " + Actions.currentScene);
       return null;
     }
 
-    logging.renderLog("SignIn", "scene = " + Actions.currentScene);
+    logging.renderLog("SignIn  scene = " + Actions.currentScene);
 
     let signedInTwitter = TwitterStore.get().twitter_sign_in_found;
     let signedInFacebook = FacebookStore.getFacebookAuthResponse().facebook_sign_in_verified;
@@ -280,9 +280,6 @@ export default class SignIn extends Component {
       }
     }
 
-    let t = this.state.voter.signed_in_twitter;
-    let f = this.state.voter.signed_in_facebook;
-
     return <View style={styles.outer_gray_pane} >
         <View style={styles.inner_white_pane} >
           <View>
@@ -297,11 +294,22 @@ export default class SignIn extends Component {
           this.state.voter.signed_in_twitter || !this.state.voter.signed_in_facebook */}
           <View style={{flex: 1, flexDirection: 'column', paddingTop: 15}}>
             <View>
-              <SocialSignIn signIn authenticator={'twitter'} buttonText={"Sign In"} />
-              <SocialSignIn signIn authenticator={'facebook'} buttonText={"Sign In"} />
-              {/* the two signOuts, may just be temporary for testing -- Oct 2017 */}
-              <SocialSignIn signOut authenticator={'twitter'} buttonText={"Sign Out"} />
-              <SocialSignIn signOut authenticator={'facebook'} buttonText={"Sign Out"} />
+              {!signedInTwitter ?
+                <SocialSignIn signIn isButton authenticator={'twitter'} buttonText={"Sign In"} />
+              : null
+              }
+              {!signedInFacebook ?
+                <SocialSignIn signIn isButton authenticator={'facebook'} buttonText={"Sign In"} />
+              : null
+              }
+              {signedInTwitter || signedInFacebook ?
+                <SocialSignIn signOut isButton authenticator={'both'} buttonText={"Sign Out"}/>
+                : null
+              }
+              {/* Please save these for testing
+              <SocialSignIn signOut isButton authenticator={'twitter'} buttonText={"Sign Out"} />
+              <SocialSignIn signOut isButton authenticator={'facebook'} buttonText={"Sign Out"} />
+              */}
             </View>
           </View>
         </View>

--- a/src/js/scenes/SignIn/SocialSignIn.js
+++ b/src/js/scenes/SignIn/SocialSignIn.js
@@ -7,13 +7,12 @@ import OAuthManager from 'react-native-oauth';
 import {AccessToken} from "react-native-fbsdk";
 
 import FacebookActions from "../../actions/FacebookActions";
+import FacebookStore from "../../stores/FacebookStore";
 import RouteConst from "../routeConst"
 import styles from "../../stylesheets/components/baseStyles"
 import TwitterActions from "../../actions/TwitterActions";
 import VoterActions from "../../actions/VoterActions";
 import VoterStore from "../../stores/VoterStore";
-
-import FacebookStore from "../../stores/FacebookStore";
 
 
 const webAppConfig = require("../../config");
@@ -215,7 +214,7 @@ export default class SocialSignIn extends Component {
        })
       .catch(err => {
         // If not authorized, throws {status: "error", msg: "No account found for twitter"}
-        console.log('manager.authorize threw an error: ...' );
+        console.log('manager.authorize threw an error: ...');
         console.log(err);
       });
     console.log('after oauthManager.deauthorize social: ' + this.props.authenticator);
@@ -223,10 +222,10 @@ export default class SocialSignIn extends Component {
 
   render () {
     if ( ( Actions.currentScene !== RouteConst.KEY_SOCIAL_SIGNIN) && ( Actions.currentScene !== RouteConst.KEY_SIGNIN) ) {
-      logging.renderLog("SocialSignIn", "when NOT CURRENT, scene  = " + Actions.currentScene);
+      logging.renderLog("SocialSignIn when NOT CURRENT, scene  = " + Actions.currentScene);
       return null;
     }
-    logging.renderLog("SocialSignIn", "scene = " + Actions.currentScene + "  hasMounted = " + this.state.hasMounted);
+    logging.renderLog("SocialSignIn scene = " + Actions.currentScene + "  hasMounted = " + this.state.hasMounted);
 
 
     let onPressFunction = null;

--- a/src/js/scenes/SignIn/TwitterSignInProcess.js
+++ b/src/js/scenes/SignIn/TwitterSignInProcess.js
@@ -138,7 +138,7 @@ export default class TwitterSignInProcess extends Component {
     if (this.state.saving ||
       !twitter_auth_response ||
       !twitter_auth_response.twitter_retrieve_attempted ) {
-      return <LoadingWheel text={['Twitter authentication was successful.', 'Retrieving more data from the WeVote Cloud.']}/>;
+      return <LoadingWheel text={['Twitter authentication was successful.', 'Retrieving more data...']}/>;
      }
 
     console.log("=== Passed initial gate ===");

--- a/src/js/scenes/SignIn/TwitterSignInProcess.js
+++ b/src/js/scenes/SignIn/TwitterSignInProcess.js
@@ -138,7 +138,7 @@ export default class TwitterSignInProcess extends Component {
     if (this.state.saving ||
       !twitter_auth_response ||
       !twitter_auth_response.twitter_retrieve_attempted ) {
-      return <LoadingWheel text={['Twitter authentication was successful.', 'Waiting for Twitter to return with additional information.']}/>;
+      return <LoadingWheel text={['Twitter authentication was successful.', 'Retrieving more data from the WeVote Cloud.']}/>;
      }
 
     console.log("=== Passed initial gate ===");
@@ -154,7 +154,8 @@ export default class TwitterSignInProcess extends Component {
       //     message_type: "success"
       //   }
       // });
-      return <LoadingWheel text={'Waiting for the WeVote cloud to return with additional information.'}/>;
+      // TODO: Replace this with a pop-up explanation
+      return <LoadingWheel text={['NOT FOR GENERAL RELEASE', 'Twitter sign in failed, for now press Command+R.']}/>;
     }
 
     if (yes_please_merge_accounts) {

--- a/src/js/stores/FacebookStore.js
+++ b/src/js/stores/FacebookStore.js
@@ -224,6 +224,14 @@ export default class FacebookStore extends FluxMapStore {
           emailData: {}
         };
 
+      case "facebookSignInForget":
+        // console.log("FacebookStore::facebookSignInForget");
+        return {
+          authData: {},
+          pictureData: {},
+          emailData: {}
+        };
+
       /* Sept 6, 2017, has been replaced by facebook Game API friends list */
       case "facebookFriendsAction":
         state.facebook_friends_using_we_vote_list = action.res.facebook_friends_using_we_vote_list;

--- a/src/js/stores/TwitterStore.js
+++ b/src/js/stores/TwitterStore.js
@@ -149,6 +149,27 @@ export default class TwitterStore extends FluxMapStore {
           ...state
         };
 
+      case "twitterSignInForget":
+        // console.log("TwitterStore::twitterSignInForget");
+        state.existing_twitter_account_found = false;
+        state.twitter_profile_image_url_https = '';
+        state.twitter_retrieve_attempted = false;
+        state.twitter_secret_key = '';
+        state.twitter_sign_in_failed = false;
+        state.twitter_sign_in_found = false;
+        state.twitter_sign_in_verified = false;
+        state.voter_device_id = '';
+        state.voter_has_data_to_preserve = false;
+        state.voter_we_vote_id = '';
+        state.voter_we_vote_id_attached_to_twitter = false;
+        state.we_vote_hosted_profile_image_url_large = '';
+        state.we_vote_hosted_profile_image_url_medium = '';
+        state.we_vote_hosted_profile_image_url_tiny = '';
+        return {
+          ...state
+        };
+
+
       default:
         return {
           ...state

--- a/src/js/stores/VoterStore.js
+++ b/src/js/stores/VoterStore.js
@@ -340,8 +340,8 @@ export default class VoterStore extends FluxMapStore {
       case "voterRetrieve":
         let current_voter_device_id = CookieStore.getItem("voter_device_id");
         if (!action.res.voter_found) {
-          // console.log("This voter_device_id is not in the db and is invalid, so delete it: " +
-          //             cookies.getItem("voter_device_id"));
+          console.log("This voter_device_id is not in the db and is invalid, so delete it: " +
+            CookieStore.getItem("voter_device_id"));
 
           CookieStore.removeItem("voter_device_id");
           // ...and then ask for a new voter. When it returns a voter with a new voter_device_id, we will set new cookie

--- a/src/js/utils/service.js
+++ b/src/js/utils/service.js
@@ -1,11 +1,3 @@
-/**
- * The idea of this APIS.js (WeVote service.js) file is to abstract away the details
- * of many repetitive service calls that we will be using.
- * @author Nick Fiorini <nf071590@gmail.com>
- */
-"use strict";
-
-import * as request from "superagent";
 import CookieStore from '../stores/CookieStore';
 
 const url = require("url");
@@ -76,20 +68,17 @@ export function $ajax (options) {
 
       logging.httpLog(">>HTTP FETCH $ajax for (" + options.endpoint + ")");
       if (responseJson.hasOwnProperty('voter_device_id')) {
-        // logging.httpLog(">>HTTP responseJson:" + options.endpoint + ' : ' + responseJson.voter_device_id + ' : ' +
-        //   responseJson.status);
-        console.log(">>HTTP responseJson:", options.endpoint, responseJson);
+        logging.httpLog(">>HTTP responseJson:" + options.endpoint + ' : ' + responseJson.voter_device_id + ' : ' +
+          responseJson.status);
       } else {
-        //logging.httpLog(">>HTTP responseJson:" + options.endpoint + ' : ' + responseJson.status);
-        console.log(">>HTTP responseJson:", options.endpoint, responseJson);
+        logging.httpLog(">>HTTP responseJson:" + options.endpoint + ' : ' + responseJson.status);
       }
-      //logging.httpLog(">>HTTP response:", responseJson);
+      logging.httpLog(">>HTTP response:", responseJson);
 
       const res = responseJson;
       this.dispatch({ type: options.endpoint, res });
     })
     .catch((error) => {
-      // Steve 11/11/17 only for iphonedevcamp console.error(">>HTTP FETCH $ajax error", error, options.endpoint);
       console.log(">>HTTP FETCH $ajax error", error, options.endpoint);
       this.dispatch({type: "error-" + options.endpoint, error});
     });


### PR DESCRIPTION
Avoided deleting the cookie, which unlike in the webapp is not instantaneous
Reworked FacebookActions, TwitterActions, and VoterSessionActions as classes
instead of module.exports, so that I could get them to work with
Dispatcher.dispatch calls.
In Ballot.js, use more rnrfConstants
Account Menu, now show working menu choices as links
SignIn logging fixes, and conditional display of the buttons
SocialSignIn logging fixes
TwitterSignInProcess, improved the LoadingWheel message
TwitterStore and FacebookStore now have SignInForget so we don't have to
delete the cookie to clear authentication.
VoterStore and service.js logging fixes.
Added WORKING_WITH_REACT_NATIVE_FLUX.md and fixed links to that new page